### PR TITLE
Fix font for Color-Reaction header

### DIFF
--- a/Projekte/Color-Reaction/colorReaction.css
+++ b/Projekte/Color-Reaction/colorReaction.css
@@ -1,14 +1,3 @@
-@font-face {
-  font-family: "montserrat";
-  src: url("fonts/montserrat/Montserrat-VariableFont_wght.ttf") format("truetype");
-}
-
-
-@font-face {
-  font-family: "montserratItalic";
-  src: url("fonts/Montserrat/Montserrat-Italic-VariableFont_wght.ttf") format("truetype");
-}
-
 html {
   scroll-behavior: smooth;
   width: 100%;
@@ -20,7 +9,7 @@ body {
     width: 100%;
     background-color: #f4f4f4;
     overflow-x: hidden;
-    font-family: "montserrat", sans;
+    font-family: "Montserrat", sans;
 }
 :root {
     --grey: #b4b0bd;
@@ -30,7 +19,7 @@ body:not(.futuristic) h1 {
       display: flex;
   align-items: center;
   justify-content: center;
-  font-family: "montserrat", sans-serif;
+  font-family: "Montserrat", sans-serif;
   font-size: 2.5rem;
   font-weight: 500;
     margin: 5% 0 0 0;
@@ -42,7 +31,7 @@ body.futuristic h1 {
         display: flex;
   align-items: center;
   justify-content: center;
-  font-family: "montserrat", sans-serif;
+  font-family: "Montserrat", sans-serif;
   font-size: 2.5rem;
   font-weight: 500;
     margin: 5% 0 0 0;
@@ -56,7 +45,7 @@ body:not(.futuristic) h2 {
   width: 90vw;
   font-size: 1.8rem;
   font-weight: 700;
-  font-family: "montserrat", sans-serif;
+  font-family: "Montserrat", sans-serif;
   margin: 3% 10% 0% 10%;
   height: 7vh;
   color: black;
@@ -69,13 +58,13 @@ body.futuristic h2 {
   width: 90vw;
   font-size: 1.8rem;
   font-weight: 700;
-  font-family: "montserrat", sans-serif;
+  font-family: "Montserrat", sans-serif;
   margin: 3% 10% 0% 10%;
   height: 7vh;
 }
 
 body:not(.futuristic) p {
-      font-family: "montserrat", sans-serif;
+      font-family: "Montserrat", sans-serif;
   font-weight: 600;
   min-height: 1rem; 
   color: black;
@@ -85,7 +74,7 @@ body:not(.futuristic) p {
 }
 
 body.futuristic p {
-      font-family: "montserrat", sans-serif;
+      font-family: "Montserrat", sans-serif;
   font-weight: 600;
   min-height: 1rem; 
   color: white;
@@ -96,7 +85,7 @@ body.futuristic p {
 
 body:not(.futuristic) ul li, 
 body:not(.futuristic) #postLaunchResearch div strong {
-    font-family: "montserrat", sans-serif;
+    font-family: "Montserrat", sans-serif;
   font-weight: 600;
   min-height: 1rem; 
   color: black;
@@ -106,7 +95,7 @@ body:not(.futuristic) #postLaunchResearch div strong {
 }
 
 body.futuristic ul li, #postLaunchResearch div strong {
-    font-family: "montserrat", sans-serif;
+    font-family: "Montserrat", sans-serif;
   font-weight: 600;
   min-height: 1rem; 
   color: #fff;
@@ -120,14 +109,14 @@ body.futuristic ul li, #postLaunchResearch div strong {
 }
 
 #postLaunchResearch div strong {
-  font-family: "montserrat", sans-serif;
+  font-family: "Montserrat", sans-serif;
   font-weight:600;
   font-size: 1.2rem;
   margin: 15px;
 }
 
 #postLaunchResearch div{
-  font-family: "montserrat", sans-serif;
+  font-family: "Montserrat", sans-serif;
   font-weight: 500;
   font-size: 1rem;
 }
@@ -214,7 +203,7 @@ body.futuristic #empathyMedia {
 .logo {
     font-size: 1.5rem;
     font-weight: 600;
-    font-family: 'montserrat', sans-serif;
+    font-family: 'Montserrat', sans-serif;
 }
 
 .site-nav {
@@ -226,13 +215,10 @@ body.futuristic #empathyMedia {
     color: var(--light);
     text-decoration: none;
     transition: color 0.3s;
-    font-family: 'montserrat', sans-serif !important;
-    font-size: 600;
+    font-family: 'Montserrat', sans-serif !important;
+    font-weight: 600;
 }
 
-.site-nav a {
-  font-family: 'Montserrat', sans-serif !important;
-}
 
 .site-nav a:hover {
     color: var(--primary);


### PR DESCRIPTION
## Summary
- remove invalid `@font-face` declarations from `Color-Reaction`
- standardize fonts to Montserrat and fix navigation styles

## Testing
- `curl -I https://fonts.googleapis.com 2>&1 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6870eb281f74832896f270989d5f0b83